### PR TITLE
Enable shell alias expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## This Fork
+
+The purpose of this fork is to expand aliases from your current shell, allowing you to run commands like `gr @something gl` when you've got `alias gl='git pull'` in your profile.
+
+To install this fork: `npm install -g @michaek/git-run`
+
 ## Features
 
 - Tag all the things! `gr @work foo` will run the command `foo` in all the paths tagged `@work`.

--- a/lib/run.js
+++ b/lib/run.js
@@ -7,7 +7,7 @@ module.exports = function(line, cwd, onDone) {
   var parts = (Array.isArray(line) ? line : line.split(' ')),
       task;
 
-  task = spawn(parts[0], parts.slice(1), {
+  task = spawn('/bin/bash', ['-l', '-O', 'expand_aliases', '-c', parts.join(' ')], {
     cwd: cwd,
     stdio: ['ignore', process.stdout, process.stderr]
   });

--- a/lib/run.js
+++ b/lib/run.js
@@ -7,7 +7,7 @@ module.exports = function(line, cwd, onDone) {
   var parts = (Array.isArray(line) ? line : line.split(' ')),
       task;
 
-  task = spawn('/bin/bash', ['-l', '-O', 'expand_aliases', '-c', parts.join(' ')], {
+  task = spawn(process.env.SHELL || '/bin/bash', ['-l', '-O', 'expand_aliases', '-c', parts.join(' ')], {
     cwd: cwd,
     stdio: ['ignore', process.stdout, process.stderr]
   });


### PR DESCRIPTION
I'm not actually sure if this is a good idea, but it works for my purposes.

I say it's optimistic, because I didn't know what flags other shells were looking for, and I was hoping -O would be a consistent flag for shell options or that shell options would be the same across shells. That's not true for zsh, which uses -o http://linux.die.net/man/1/zsh

I'm opening the pull request to start a discussion. If it seems useful, I can see about getting this working with other shells.

Thanks for a gr-eat tool. :)