### PR TITLE
fix exception in find-by-subdir.js

### DIFF
--- a/lib/find-by-subdir.js
+++ b/lib/find-by-subdir.js
@@ -37,26 +37,27 @@ function find(directories, dirpath, baseNameList) {
     return;
   }
   // else, readdir
-  var items = fs.readdirSync(p);
-  // is any of the items a potential match?
-  isMatch = items.some(function(basename) {
-    return baseNameList.some(function(name) {
-      // must be .git | .hg dir
-      var result = (basename == name && fs.statSync(p + basename).isDirectory());
-      if (result) {
-        // console.log(p + basename);
-        directories.push(p + basename);
-      }
-      return result;
+  try {
+    var items = fs.readdirSync(p);
+    // is any of the items a potential match?
+    isMatch = items.some(function(basename) {
+      return baseNameList.some(function(name) {
+        // must be .git | .hg dir
+        var result = (basename == name && fs.statSync(p + basename).isDirectory());
+        if (result) {
+          // console.log(p + basename);
+          directories.push(p + basename);
+        }
+        return result;
+      });
     });
-  });
-  // is a direct subdir a match?
-  if (isMatch) {
-    // go no further
-    return;
-  }
-  // else, we must iterate into any directories
-  items.filter(function(path) {
+    // is a direct subdir a match?
+    if (isMatch) {
+      // go no further
+      return;
+    }
+    // else, we must iterate into any directories
+    items.filter(function(path) {
       // avoid recursing into directories that start with `.`
       return path.charAt(0) != '.';
     }).map(function(f) {
@@ -66,6 +67,10 @@ function find(directories, dirpath, baseNameList) {
         directories.push(i);
       }
     });
+  }
+  catch (e) {
+      console.log("unable to access: " + e);
+  }
   return;
 }
 


### PR DESCRIPTION
When readdirSync is called on a directory e.g. without read permission
the whole search is aborted. With this commit a log is printed instead.

This solves issue #13 .