### PR TITLE
Add a path option to "gr tag discover"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ Use the auto-discovery feature to set up tags quickly:
 
     gr tag discover
 
-Auto-discovery searches all paths under your home directory, generates a list, and opens it in your default console editor.
+By default auto-discovery searches all paths under your home directory.
+
+If you'd prefer, you can specify a directory under which auto-discovery should search:
+
+    gr tag discover /mnt/external/projects
+
+Once auto-discovery completes, it will generate a list, and open it in your default console editor.
 
 It will look like this:
 

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -40,12 +40,13 @@ Tags can also be specified more explicitly; this is useful if you are using a sc
 ## Built-in commands:
 
 gr tag ..
-  add <t>         Add a tag to the current directory
-  rm <t>          Remove a tag from the current directory
-  add <t> <path>  Add a tag to <path>
-  rm <t> <path>   Remove a tag from <path>
-  list            List all tags (default action)
-  discover        Auto-discover git paths under ~/
+  add <t>           Add a tag to the current directory
+  rm <t>            Remove a tag from the current directory
+  add <t> <path>    Add a tag to <path>
+  rm <t> <path>     Remove a tag from <path>
+  list              List all tags (default action)
+  discover <path>   Auto-discover git paths under <path>
+                    (<path> defaults to ~/ if omitted)
 
 gr list        List all known repositories and their tags
 

--- a/plugins/tag.js
+++ b/plugins/tag.js
@@ -107,7 +107,8 @@ var spawn = require('child_process').spawn,
     findBySubdir = require('../lib/find-by-subdir.js');
 
 function discover(req, res, next) {
-  var repos = (req.gr.directories ? req.gr.directories : []),
+  var discoverPath = (req.argv ? req.argv[0] : req.gr.homePath),
+      repos = (req.gr.directories ? req.gr.directories : []),
       pathMaxLen = repos.reduce(function(prev, current) {
         return Math.max(prev, current.replace(req.gr.homePath, '~').length + 2);
       }, 0);
@@ -117,10 +118,9 @@ function discover(req, res, next) {
       new Array(len - s.toString().length).join(' ') : '');
   }
 
-
   var editor = process.env['GIT_EDITOR'] || process.env['EDITOR'] || 'nano',
       tmpfile = os.tmpDir() + '/gr-repos-tmp.txt',
-      gitPaths = findBySubdir(req.gr.homePath, ['.git']),
+      gitPaths = findBySubdir(discoverPath, ['.git']),
       append = '';
 
   // for each git path:


### PR DESCRIPTION
If a user has a particularly complex home directory or
would like the convenience of discovering only some subsection
of git repositories, it may be useful to specify a specific path
to discover within.

This commit provides this fucntionality by adding an optional <path>
argument to the tag discover command. When <path> is omitted the
discover path will default to the home directory to maintain existing
functionality. Otherwise the path will be used as the root of the
discovery search.

This fixes issue #7