### PR TITLE
Allow gr tag discover to take multiple paths

### DIFF
--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -45,8 +45,8 @@ gr tag ..
   add <t> <path>    Add a tag to <path>
   rm <t> <path>     Remove a tag from <path>
   list              List all tags (default action)
-  discover <path>   Auto-discover git paths under <path>
-                    (<path> defaults to ~/ if omitted)
+  discover <paths>  Auto-discover git paths under the list of <paths>
+                    (If omitted, <paths> defaults to ~/)
 
 gr list        List all known repositories and their tags
 

--- a/plugins/tag.js
+++ b/plugins/tag.js
@@ -107,7 +107,7 @@ var spawn = require('child_process').spawn,
     findBySubdir = require('../lib/find-by-subdir.js');
 
 function discover(req, res, next) {
-  var discoverPath = (req.argv.length > 0 ? req.argv[0] : req.gr.homePath),
+  var discoverPaths = (req.argv.length > 0 ? req.argv : [req.gr.homePath]),
       repos = (req.gr.directories ? req.gr.directories : []),
       pathMaxLen = repos.reduce(function(prev, current) {
         return Math.max(prev, current.replace(req.gr.homePath, '~').length + 2);
@@ -120,8 +120,12 @@ function discover(req, res, next) {
 
   var editor = process.env['GIT_EDITOR'] || process.env['EDITOR'] || 'nano',
       tmpfile = os.tmpDir() + '/gr-repos-tmp.txt',
-      gitPaths = findBySubdir(discoverPath, ['.git']),
+      gitPaths = [],
       append = '';
+
+  discoverPaths.forEach(function(path) {
+    gitPaths = gitPaths.concat(findBySubdir(path, ['.git']));
+  });
 
   // for each git path:
   gitPaths.sort().forEach(function(dir) {


### PR DESCRIPTION
As suggested by @mixu, it may be convenient to be able
to specify multiple paths at once when performing auto-discovery.
This provides the functionality by allowing auto-discovery to
take a variable length list of paths, defaulting to ~/ if none
are provided.

Commit implements suggestions from pull request #36