### PR TITLE
expand the path when a relative path is used with discover

### DIFF
--- a/plugins/tag.js
+++ b/plugins/tag.js
@@ -175,6 +175,7 @@ function discover(req, res, next) {
     var tags, humanDir;
     // 1) normalize by taking dirname, changing homePath to ~/ and sorting
     dir = path.dirname(dir);
+    dir = path.resolve(dir);
     humanDir = dir.replace(new RegExp('^' + req.gr.homePath + '/'), '~/')
                   .replace(/ /g, '\\ ');
     // 2) search for matching tags


### PR DESCRIPTION
This seems to fix the issue of getting a relative path in the configuration when using a path on the "gr discover" command line which is Issue 43.

There are not any automated tests for this feature, unfortunately.