### PR TITLE
Clarified help text for list commands

### DIFF
--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -48,8 +48,8 @@ gr tag ..
 gr tag discover <paths> Auto-discover git paths under  the list of <paths>
                     (If omitted, <paths> defaults to ~/)
 
-gr tag list    List all known repositories and their tags
-gr list        List all known repositories and their tags
+gr tag list    List all known repositories, grouped by their tags
+gr list        List all known repositories
 
 gr status       Displays the (git) status of the selected directories.
 gr status -v    Runs "git status -sb" for a more verbose status.


### PR DESCRIPTION
I've seen the fix in #41, but I still find this confusing. The help message for both `gr list` and `gr tag list` is the same: _List all known repositories and their tags_, but the output is very different.

* `gr list` lists all known repositories, but does not show any tag information.
* `gr tag list` lists all known repositories, grouped by tag.

It looks like the help message for `gr list` should be updated. This PR tries to address this.