### PR TITLE
Listing each project on a new line instead of separated by commas

### DIFF
--- a/plugins/tag.js
+++ b/plugins/tag.js
@@ -66,7 +66,7 @@ function list(req, res, next) {
       console.log(
         style('Paths tagged ', 'gray') +
         style('@' + req.argv[0], 'white') +
-        ': ' + obj.join(', ')
+        ':\n ' + obj.join('\n ')
       );
     } else {
       console.log(JSON.stringify(obj, null, 2));
@@ -79,9 +79,9 @@ function list(req, res, next) {
           console.log(
             style('Paths tagged ', 'gray') +
             style('@' + tag, 'white') +
-            ': ' + (Array.isArray(val) ? val.map(function(s) {
+            ':\n ' + (Array.isArray(val) ? val.map(function(s) {
               return s.replace(req.gr.homePath, '~');
-            }).join(', ') : val)
+            }).join('\n ') : val)
           );
       });
     } else {


### PR DESCRIPTION
I found the output of `git tag list` to be hard to read, with all of the projects under each tag only separated by comma. With lots of projects, it was nearly impossible to get an overview of what is where.

I've changed this to one project per line, which is a lot easier to read.

Before - worse if you factor in line breaks in the terminal:

```
Paths tagged @splenk: ~/workspaces/splenk-git/splenk-framework-build, ~/workspaces/splenk-git/splenk-framework-build/packages, ~/workspaces/splenk-git/splenk-framework-build/modules/foo-work, ~/workspaces/splenk-git/splenk-framework-build/themes/splenk-theme-boo, ~/workspaces/splenk-git/splenk-framework-build/themes/splenk-theme-buzz, ~/workspaces/splenk-git/splenk-framework-build/framework/splenk-sk, ~/workspaces/splenk-git/splenk-framework-build/framework/splenk-widgets, ~/workspaces/splenk-git/splenk-framework-build/framework/splenk-components, ~/workspaces/splenk-git/splenk-framework-build/framework/splenk-shell, ~/workspaces/splenk-git/splenk-framework-build/framework/splenk-framework, ~/workspaces/splenk-git/splenk-framework-build/demo/demo-services, ~/workspaces/splenk-git/splenk-framework-build/demo/desktop/desktop-ui, ~/workspaces/splenk-git/splenk-framework-build/demo/desktop/desktop-demo
Paths tagged @aacc4: ~/workspaces/FOO/configuration, ~/workspaces/FOO/solution-artifacts
```

After:

```
Paths tagged @splenk:
 ~/workspaces/splenk-git/splenk-framework-build
 ~/workspaces/splenk-git/splenk-framework-build/packages
 ~/workspaces/splenk-git/splenk-framework-build/modules/foo-work
 ~/workspaces/splenk-git/splenk-framework-build/themes/splenk-theme-boo
 ~/workspaces/splenk-git/splenk-framework-build/themes/splenk-theme-buzz
 ~/workspaces/splenk-git/splenk-framework-build/framework/splenk-sk
 ~/workspaces/splenk-git/splenk-framework-build/framework/splenk-widgets
 ~/workspaces/splenk-git/splenk-framework-build/framework/splenk-components
 ~/workspaces/splenk-git/splenk-framework-build/framework/splenk-shell
 ~/workspaces/splenk-git/splenk-framework-build/framework/splenk-framework
 ~/workspaces/splenk-git/splenk-framework-build/demo/demo-services
 ~/workspaces/splenk-git/splenk-framework-build/demo/desktop/desktop-ui
 ~/workspaces/splenk-git/splenk-framework-build/demo/desktop/desktop-demo
Paths tagged @aacc4:
 ~/workspaces/FOO/configuration
 ~/workspaces/FOO/solution-artifacts
```

Not sure whether this change is too invasive - maybe it should be optional.
