### PR TITLE
Fix test configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TESTS += test/*.test.js
 
 test:
-	@mocha \
+	@node_modules/.bin/mocha \
 		--reporter spec \
 		--slow 2000ms \
 		--bail \

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A tool for managing multiple git repositories",
   "main": "index.js",
   "scripts": {
-    "test": "make tests"
+    "test": "make test"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,8 @@
     "tabtab": "git+https://github.com/mixu/node-tabtab.git"
   },
   "devDependencies": {
-    "file-fixture": "0.0.2"
+    "file-fixture": "0.0.2",
+    "mocha": "^3.2.0"
   },
   "jshintConfig": {
     "-W018": true,


### PR DESCRIPTION
The package.json was referencing a make target that didn't exist.
The makefile used a global mocha instead on one managed for this repo in the package.jsoN