### PR TITLE
Use `git rev-parse` to check path correctness

### DIFF
--- a/lib/command-requirements.js
+++ b/lib/command-requirements.js
@@ -1,31 +1,23 @@
 var fs = require('fs'),
-    path = require('path');
+    path = require('path'),
+    spawnSync = require('child_process').spawnSync;
 
 module.exports = {
-  git: function(req) {
-    var stat;
-    try {
-      stat = fs.statSync(req.path + '/.git/');
-      if (stat.isDirectory()) {
-        return true;
+  git: function (req) {
+    var gitCommand = spawnSync('git', ['rev-parse', '--show-prefix'], {cwd: req.path});
+    if (gitCommand.stderr.toString().replace(/(\r\n|\n|\r)/gm, '').trim()) {
+      if (req.format === 'human') {
+        console.log('Skipped ' + req.path + ' as it is not a Git repository.');
       }
-    } catch (e) {
-      // check if the directory is a submodule
-      // addresses https://github.com/mixu/gr/issues/54
-      if (e.code === 'ENOTDIR' || e.code === 'ENOENT') {
-        var parentPath = path.dirname(req.path);
-        try {
-          stat = fs.statSync(parentPath + '/.gitmodules');
-          if (stat.isFile()) {
-            return true;
-          }
-        } catch (e) { }
+      return false;
+    }
+    if (gitCommand.stdout.toString().replace(/(\r\n|\n|\r)/gm, '').trim()) {
+      if (req.format === 'human') {
+        console.log('Skipped ' + req.path + ' as it is not the root of Git repository or submodule.');
       }
+      return false;
     }
-    if (req.format === 'human') {
-      console.log('Skipped ' + req.path + ' as it does not have a .git subdirectory and is not a submodule.');
-    }
-    return false;
+    return true;
   },
   make: function(req) {
     var stat;


### PR DESCRIPTION
Instead of check the existness of `.git` directory, use `git rev-parse`
to check that `req.path` is in

* a Git repository
* a Git submodule
* the root of the repo/submodule

The old method didn't worked with submodules more than one level deep in
the repo. Besides this if the $GIT_DIR differs from `.git` (cannot find
a real life example), then the old method fails to work.

Related to #54 

It's using `git rev-parse --show-prefix` which drops error if executed outside of Git repository; prints the prefix ("the current directory relative to Git root") if executed from a subdirectory. The behaviour if equal for Git repo and submodule too.

Curently it's not working because I can't return true/false from exec, so I need help in making it usable.

Please be patient, it's my very first Node.js code and I'm beginner in Javascript too.