### PR TITLE
Fixes issue #66 so submodules are detected properly.

### DIFF
--- a/lib/command-requirements.js
+++ b/lib/command-requirements.js
@@ -1,31 +1,21 @@
 var fs = require('fs'),
-    path = require('path');
+    path = require('path'),
+    execSync = require('child_process').execSync;
 
 module.exports = {
   git: function(req) {
-    var stat;
     try {
-      stat = fs.statSync(req.path + '/.git/');
-      if (stat.isDirectory()) {
-        return true;
-      }
+      execSync('git rev-parse --is-inside-git-dir', {
+        cwd: req.path,
+        stdio: 'ignore'
+      });
     } catch (e) {
-      // check if the directory is a submodule
-      // addresses https://github.com/mixu/gr/issues/54
-      if (e.code === 'ENOTDIR' || e.code === 'ENOENT') {
-        var parentPath = path.dirname(req.path);
-        try {
-          stat = fs.statSync(parentPath + '/.gitmodules');
-          if (stat.isFile()) {
-            return true;
-          }
-        } catch (e) { }
+      if (req.format === 'human') {
+        console.log('Skipped ' + req.path + ' as it does not have a .git subdirectory and is not a submodule.');
       }
+      return false;
     }
-    if (req.format === 'human') {
-      console.log('Skipped ' + req.path + ' as it does not have a .git subdirectory and is not a submodule.');
-    }
-    return false;
+    return true;
   },
   make: function(req) {
     var stat;


### PR DESCRIPTION
As mentioned in #66, executing the command `git rev-parse --is-inside-git-dir` is a more full-proof way of checking for a valid git directory. It should work in all cases.  This would be in favor of #65, which is still a WIP and aims to do the same thing.