### PR TITLE
[bugfix]: when discovering tags, ignore ELOOP filesystem errors that can occur with circular symlinks

### DIFF
--- a/plugins/tag.js
+++ b/plugins/tag.js
@@ -153,7 +153,8 @@ function discover(req, res, next) {
     } catch (e) {
       // ignore ENOENT (can occur with bad symlinks)
       // and EACCESS (can occur with superuser-permission paths)
-      if (e.code !== 'ENOENT' && e.code !== 'EACCES') {
+      // and ELOOP (can occur when encounters circular symlink)
+      if (e.code !== 'ENOENT' && e.code !== 'EACCES' && e.code != 'ELOOP') {
         throw e;
       }
     }


### PR DESCRIPTION
`Error: ELOOP: too many symbolic links encountered, stat <...path>`

Ran into this on a large set of repos one of which contained a circular symlink. We can skip that error since we are just trying to discover git directories / tags.

@mixu 