### PR TITLE
add interact command; run + interactive subshells

### DIFF
--- a/bin/gr
+++ b/bin/gr
@@ -70,6 +70,9 @@ gr.use('export', exportPlugin.exportAsJson);
 // import plugin
 gr.use('import', importPlugin.importFromJson);
 
+// interactive run
+gr.use('interact', require('../plugins/interact.js'));
+
 // default: run the remainder as a shell task
 gr.use('--', require('../plugins/run.js'));
 gr.use(require('../plugins/run.js'));

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,16 +1,12 @@
 var spawn = require('child_process').spawn,
+    spawnSync = require('child_process').spawnSync,
     exec = require('child_process').exec,
     path = require('path'),
     style = require('./style.js');
 
-module.exports = function(line, cwd, onDone) {
+module.exports = function(line, cwd, onDone, interactive) {
   var parts = (Array.isArray(line) ? line : line.split(' ')),
       task;
-
-  task = spawn(parts[0], parts.slice(1), {
-    cwd: cwd,
-    stdio: ['ignore', process.stdout, process.stderr]
-  });
 
   function onClose(code) {
     if (code !== 0) {
@@ -19,16 +15,33 @@ module.exports = function(line, cwd, onDone) {
       // task.emit('error', new Error('Child process exited with nonzero exit code: '+ code));
     }
   }
-  task.once('error', function(err) {
-    if (err.code === 'ENOENT') {
-      console.log('ENOENT error executing the command "' + parts.join(' ') +'" in ' + cwd + '. Please make sure you have installed an executable named "' + parts[0] + '" in $PATH.');
-    } else {
-      throw err;
-    }
-  });
 
-  // Node <= 0.8x
-  task.once('exit', onClose);
-  // Node >= 0.10.x
-  task.once('close', onDone);
+  if (interactive) {
+    task = spawnSync(parts[0], parts.slice(1), {
+      cwd: cwd,
+      stdio: 'inherit'
+    });
+
+    onClose(task.status);
+    onDone();
+  }
+  else {
+    task = spawn(parts[0], parts.slice(1), {
+      cwd: cwd,
+      stdio: ['ignore', process.stdout, process.stderr]
+    });
+
+    task.once('error', function(err) {
+      if (err.code === 'ENOENT') {
+        console.log('ENOENT error executing the command "' + parts.join(' ') +'" in ' + cwd + '. Please make sure you have installed an executable named "' + parts[0] + '" in $PATH.');
+      } else {
+        throw err;
+      }
+    });
+
+    // Node <= 0.8x
+    task.once('exit', onClose);
+    // Node >= 0.10.x
+    task.once('close', onDone);
+  }
 };

--- a/plugins/interact.js
+++ b/plugins/interact.js
@@ -1,0 +1,45 @@
+var log = require('minilog')('gr-run'),
+    path = require('path'),
+    style = require('../lib/style.js'),
+    run = require('../lib/run.js'),
+    commandRequirements = require('../lib/command-requirements.js');
+
+module.exports = function(req, res, next) {
+
+  // if argv is empty, skip
+  if (req.argv.length === 0) {
+    return next();
+  }
+
+  // assume that the rest of the argvs are the command
+  var task = req.argv,
+      dirname = path.dirname(req.path).replace(req.gr.homePath, '~') + path.sep;
+
+  if (task[0] == 'interact') {
+    task.shift();
+  }
+
+  if (task[0] == 'git') {
+    // for "git" tasks, add the color option
+    // task.splice(1, 0, '-c color.ui=always');
+    // disabled for now, as it causes some issues with commands, maybe need to
+    // insert as array items?
+  }
+  if (commandRequirements[task[0]]) {
+    if (!commandRequirements[task[0]](req)) {
+      return req.done();
+    }
+  }
+
+  if (req.format == 'human') {
+    console.log(
+      style('\nin ' + dirname, 'gray') +
+      style(path.basename(req.path), 'white') + '\n'
+      );
+  }
+
+  // always directly pass the full array,
+  // stringifying here is harmful because it will lose quoted strings
+  // which are unquoted by the shell on invocation
+  run(task, req.path, req.done, true);
+};


### PR DESCRIPTION
add interactive option to lib run and expose via `interact` command so you can run interactive processes with git-run, IE `git add -i`

there's probably a cleaner way to do this. I first tried to add a `-i` command line switch but gave up and created the new interact command which is basically the run plugin with one small change.